### PR TITLE
Add google group link and design document template

### DIFF
--- a/docs/source/developer/Design_Doc_Template.md
+++ b/docs/source/developer/Design_Doc_Template.md
@@ -1,0 +1,49 @@
+# Software Design Documentation template
+
+<span style="font-size:larger;"><b>Name of design</b></span>
+<!-- Note you can add this to an issue or pull request in github. That is the normal usage of this template. -->
+
+**Date:**
+
+**Written By:**
+
+## Introduction
+<!--What is the goal of the software? What is the problem statement
+
+If there are any specification documents, link them in Appendix.-->
+
+## Solutions
+<!--Section should include alternative implementations/solutions
+
+Is it feasible? How much effort does it need for each approach? Pros/cons of each approach.
+
+Document alternatives, why you made the decision and how it will affect the team and project.-->
+
+## Design Considerations
+<!--Describe the issues that need to be addressed before creating a design solution.-->
+
+### Assumptions and Dependencies
+<!--Describe any assumptions that may be wrong or any dependencies on other things-->
+
+### General Contraints
+<!--Describe any constraints that could have an impact on the design of the software.-->
+
+## Design and Architecture
+
+### System diagram or flowchart
+<!--Interaction diagram of various inputs, outputs, sub systems and dependencies.-->
+
+### Algorithm or Pseudo code for main components
+<!--Describe your logic in this section-->
+
+## Rollout Plan
+<!--Define the roll-out phases and tests you plan to do-->
+
+## Appendix
+<!--References, links to additional documentation-->
+
+## Review Sign-off
+#### Reviewer(s)
+- Reviewer 1: 
+
+*Sign-off Completed on YYYY-MM-DD*

--- a/docs/source/developer/reference.rst
+++ b/docs/source/developer/reference.rst
@@ -1,8 +1,8 @@
 Reference
 =========
 
-Description of code as clearly as possible
-Information oriented
-Austere and to the point
-Food analogy: Encyclopedia article about ingredient (not how to use it)
+.. toctree::
+   :maxdepth: 1
+   
+   Design_Doc_Template
 

--- a/docs/source/developer/style.rst
+++ b/docs/source/developer/style.rst
@@ -1,4 +1,4 @@
-Style Guide
+FATES Style Guide
 -----------
 
 Code development has style considerations.  Should you capitalize variables.. or not?  How many characters should the maximum width of a text line be?  Should you use long blocks of ``====``   or ``-----`` to indicate visual breaks in code.   Do we like underscores or dashes?  

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,12 +34,14 @@ This structure adapts the `Divio documentation framework`_.
 Technical Documentation
 -----------------------
 
-The :doc:`fates-doc:fates_tech_note` detailing the scientific underpinning of the model is hosted as a Read The Docs :doc:`rtd:subprojects` within this User's Guide.  As a subproject both the guide and the techincal documentation are searchable through the index in the User's Guide.
+The :doc:`fates-doc:fates_tech_note` detailing the scientific underpinning of the model is hosted as a Read The Docs :doc:`rtd:subprojects` within this User's Guide.  As a subproject both the guide and the techincal documentation are searchable through the index in this User's Guide.
 
 Getting Help
 ------------
 
 If you have questions about using fates that are not answered by this documentation, please reach out to us at the `fates github discussions board`_.  We will strive to update this documentation to cover answers provided in that forum as timely as possible.  
+
+To receive email updates about forthcoming release tags, regular meeting notifications, and other important announcements, please join the `FATES Google group`_.
 
 Requesting changes to this documentation
 ----------------------------------------
@@ -52,3 +54,4 @@ If there is information in the *technical documentation* that you would like to 
 .. _fates github discussions board: https://github.com/ngeet/fates/discussions
 .. _fates-users-guide github repository: https://github.com/ngeet/fates-users-guide/issues
 .. _fates-docs github repository: https://github.com/ngeet/fates-docs/issues
+.. _Fates Google group: https://groups.google.com/g/fates_model


### PR DESCRIPTION
This PR adds a link to the FATES Google Group directing people to sign up to the list if they would like updates, particularly about the every other week FATES modelling meeting.

This also adds an unrelated item: in an effort to adopt the design documentation idea that @adrifoster introduced to the ctsm and fates teams, I've added the template to the fates developer's reference section.  Theoretically, the completed design documents could simply be added to the developer's reference section for posterity.  This still needs to be discussed however.