### PR TITLE
Add and implementation notes section to elm-fates fire design doc

### DIFF
--- a/docs/source/developer/design_doc_template.rst
+++ b/docs/source/developer/design_doc_template.rst
@@ -52,6 +52,10 @@ Future Update Plan
 ------------------
 .. Sketch out future updates if known
 
+Implementation Notes and Lessons Learned
+----------------------------------------
+.. Optional section summarizing lessons learned after the design has been successfully implemented
+
 Appendix
 --------
 .. References, links to additional documentation

--- a/docs/source/developer/elm-fates-fire-design_doc.rst
+++ b/docs/source/developer/elm-fates-fire-design_doc.rst
@@ -61,9 +61,6 @@ Future Update Plan
 
 1. There is a new ML surrogate wildfire model being developed by Qing (LBNL), Riley (LBNL), Randerson (UCI), and Xu (UCI) that is targeted for incorpation into E3SM V4.  FATES is targeted for integration during this version as well.  There are discussions to be planned to help understand and coordinate future elm-side updates to accomodate both fire models.  
 
-Appendix
---------
-
 Implementation Notes and Lessons Learned
 ----------------------------------------
 
@@ -74,3 +71,6 @@ Implementation Notes and Lessons Learned
    elmfatesinterfacemod -> AllocationMod -> controlMod -> ndepStreamMod -> FireDataBaseType -> FATESFireBase -> elmfatesinterfacemod
 
 The circular dependency was rectified by refactoring the nitrogen deposition initialization procedure so that it would receive the namelist filename, `NLFilename`, as a character input instead of using the variable directly from controlMod.F90.
+
+Appendix
+--------

--- a/docs/source/developer/elm-fates-fire-design_doc.rst
+++ b/docs/source/developer/elm-fates-fire-design_doc.rst
@@ -22,7 +22,7 @@ General Constraints
 
 - The goal is to enable elm-fates to utilize the same inputs as available through the clm-fates API to facilitate near-term FATES benchmarking goals.  As such, the data input methodologies should deviate from the clm-fates API as little as possible.
 - The elm cn-fire code uses `use_cn` logic checks to trigged or avoid fire data interpolation which includes lightning frequecy and HDM.  To enable FATES to utilize this procedure, these check may need to be refactored.  
-- The FATES fire data run modes are currently controlled through namelist options and as such will need an update to the ELM build namelist PERL code.
+- The FATES fire data run modes are currently controlled through namelist options and as such will need an update to the ELM build namelist XML settings.
 
 Solutions
 ---------
@@ -64,13 +64,15 @@ Future Update Plan
 Implementation Notes and Lessons Learned
 ----------------------------------------
 
-- Due to pre-existing elm-fates nutrients implementation (which has not been ported to clm-fates) a circular dependency was created when the fire model data stream procedures were being called by elmfates_interfaceMod.F90.  This was partially due to the fact that the `hlm_fates_interface_type` is being used by AllocationMod.F90 to provide access to fates nutrients outputs to elm.  The dependency chain consisted of:
+Due to pre-existing elm-fates nutrients implementation (which has not been ported to clm-fates) a circular dependency was created when the fire model data stream procedures were being called by elmfates_interfaceMod.F90.  This was partially due to the fact that the `hlm_fates_interface_type` is being used by AllocationMod.F90 to provide access to fates nutrients outputs to elm.  The dependency chain consisted of:
 
 .. code-block::
 
    elmfatesinterfacemod -> AllocationMod -> controlMod -> ndepStreamMod -> FireDataBaseType -> FATESFireBase -> elmfatesinterfacemod
 
 The circular dependency was rectified by refactoring the nitrogen deposition initialization procedure so that it would receive the namelist filename, `NLFilename`, as a character input instead of using the variable directly from controlMod.F90.
+
+Prior to implementation, it was considered, although not ellaborated above, that it might be possible to reuse the existing FireMod data initialization and interpolation subroutines so as to reduce code duplication.  Ulimately, these procedures were duplicated given that reuse would have presented more complexity than it was worth.  Additionally, it was considered a potential benefit in that a future elm fire module update might find it advantageous and make use of the new fire base types that contain these procedures.
 
 Appendix
 --------

--- a/docs/source/developer/elm-fates-fire-design_doc.rst
+++ b/docs/source/developer/elm-fates-fire-design_doc.rst
@@ -20,8 +20,8 @@ Assumptions and Dependencies
 General Constraints
 ^^^^^^^^^^^^^^^^^^^
 
-- The goal is to enable elm-fates to utilize the same inputs as available through the clm-fates API to facilitate near-term FATES benchmarking goals.  As such, the data input methodlogies should deviate from the clm-fates API as little as possible.
-- The elm cn-fire code uses `use_cn` logic checks to trigged or avoid fire data interpolation which includes lightning frequecy and HDM.  To enable FATES to utilize this procedure, the check will need to be refactored.  
+- The goal is to enable elm-fates to utilize the same inputs as available through the clm-fates API to facilitate near-term FATES benchmarking goals.  As such, the data input methodologies should deviate from the clm-fates API as little as possible.
+- The elm cn-fire code uses `use_cn` logic checks to trigged or avoid fire data interpolation which includes lightning frequecy and HDM.  To enable FATES to utilize this procedure, these check may need to be refactored.  
 - The FATES fire data run modes are currently controlled through namelist options and as such will need an update to the ELM build namelist PERL code.
 
 Solutions
@@ -63,3 +63,14 @@ Future Update Plan
 
 Appendix
 --------
+
+Implementation Notes and Lessons Learned
+----------------------------------------
+
+- Due to pre-existing elm-fates nutrients implementation (which has not been ported to clm-fates) a circular dependency was created when the fire model data stream procedures were being called by elmfates_interfaceMod.F90.  This was partially due to the fact that the `hlm_fates_interface_type` is being used by AllocationMod.F90 to provide access to fates nutrients outputs to elm.  The dependency chain consisted of:
+
+..code-block::
+
+   elmfatesinterfacemod -> AllocationMod -> controlMod -> ndepStreamMod -> FireDataBaseType -> FATESFireBase -> elmfatesinterfacemod
+
+The circular dependency was rectified by refactoring the nitrogen deposition initialization procedure so that it would receive the namelist filename, `NLFilename`, as a character input instead of using the variable directly from controlMod.F90.

--- a/docs/source/developer/elm-fates-fire-design_doc.rst
+++ b/docs/source/developer/elm-fates-fire-design_doc.rst
@@ -66,7 +66,7 @@ Implementation Notes and Lessons Learned
 
 - Due to pre-existing elm-fates nutrients implementation (which has not been ported to clm-fates) a circular dependency was created when the fire model data stream procedures were being called by elmfates_interfaceMod.F90.  This was partially due to the fact that the `hlm_fates_interface_type` is being used by AllocationMod.F90 to provide access to fates nutrients outputs to elm.  The dependency chain consisted of:
 
-..code-block::
+.. code-block::
 
    elmfatesinterfacemod -> AllocationMod -> controlMod -> ndepStreamMod -> FireDataBaseType -> FATESFireBase -> elmfatesinterfacemod
 


### PR DESCRIPTION
I thought it would be helpful to briefly summarize some lessons learned during the implementation of the design doc, so I've added that to the elm-fates fire doc as well as an optional section to the template.