### PR TITLE
Update inventory initialization section to reflect simplified file formats

### DIFF
--- a/docs/source/user/Model-Initialization-Modes.md
+++ b/docs/source/user/Model-Initialization-Modes.md
@@ -61,7 +61,6 @@ TYPE LATITUDE LONGITUDE PSS_PATH CSS_PATH
 
 === Inventory Format Type 1 ===
 
-Type 1 inventory files are designed to be compliant with ED2 css/pss files, see:  https://github.com/EDmodel/ED2/wiki/Initial-conditions
 
 ''Patch'' file format (*.pss)
 
@@ -92,37 +91,6 @@ Type 1 inventory files are designed to be compliant with ED2 css/pss files, see:
 |proportion
 |Fractional area represented by patch.  For format 1 is area in m2
 |-
-|water
-|m3/m3 ??
-|Not actually read
-|-
-|fsc
-|Kg/m2
-|Fast soil carbon
-|-
-|stsc
-|Kg/m2
-|Structural soil carbon
-|-
-|stsl
-|Kg/m2
-|Structural soil lignin
-|-
-|ssc
-|Kg/m2
-|Slow soil carbon
-|-
-|psc
-|Kg/m2
-|Passive soil carbon (not actually read)
-|-
-|msn
-|Kg/m2
-|Mineralized soil N
-|-
-|fsn
-|Kg/m2
-|Fast soil N
 |}
 
 ''Cohort'' file format (*.css)
@@ -147,10 +115,6 @@ Type 1 inventory files are designed to be compliant with ED2 css/pss files, see:
 |cm
 |Stem diameter breast height
 |-
-|hite
-|m
-|Tree height
-|-
 |pft
 |integer
 |Plant Functional Type
@@ -159,17 +123,6 @@ Type 1 inventory files are designed to be compliant with ED2 css/pss files, see:
 |Stem/m2
 |Stem density
 |-
-|bdead
-|KgC/plant
-|Structural carbon
-|-
-|balive
-|KgC/plant
-|“Live” carbon (leaf, fine root, sapwood) 
-|-
-|Avgrg
-|
-|No longer used (was average radial growth)
 |}
 
 

--- a/docs/source/user/Model-Initialization-Modes.md
+++ b/docs/source/user/Model-Initialization-Modes.md
@@ -64,65 +64,24 @@ TYPE LATITUDE LONGITUDE PSS_PATH CSS_PATH
 
 ''Patch'' file format (*.pss)
 
-{| border="1"
-!Variable
-!Units
-!Description
-|-
-|time
-|years
-|Year
-|-
-|patch
-|String
-|Patch identifier (arbitrary, any unique string that can be used to match cohorts)
-|-
-|trk
-|0 – non-forest
-1 – secondary
-2 - primary
-|Vegetation type/history
-|-
-|age
-|years
-|Patch age since disturbance
-|-
-|area
-|proportion
-|Fractional area represented by patch.  For format 1 is area in m2
-|-
-|}
+| Variable  | Units | Description |
+|-----------|-------|------------ |
+| time      |years  | Year        |
+|patch      |String |Patch identifier (arbitrary, any unique string that can be used to match cohorts) |
+|trk        |0 – non-forest, 1 – secondary, 2 - primary |Vegetation type/history |
+|age        |years  |Patch age since disturbance |
+|area |proportion |Fractional area represented by patch.  For format 1 is area in m2 |
+
 
 ''Cohort'' file format (*.css)
-{| border="1"
-! Variable
-! Unit
-! Description
-|-
-| time
-| year
-| year
-|-
-| patch
-| string
-| Unique identifier (the string matching with the patch its on)
-|-
-|cohort
-|string
-|Unique identifier (arbitrary, not used)
-|-
-|dbh
-|cm
-|Stem diameter breast height
-|-
-|pft
-|integer
-|Plant Functional Type
-|-
-|n
-|Stem/m2
-|Stem density
-|-
-|}
+
+| Variable | Unit | Description |
+|----------|------|-------------|
+| time  | year | year |
+| patch | string | Unique identifier (the string matching with the patch its on) |
+| dbh |cm |Stem diameter breast height |
+| pft |integer |Plant Functional Type |
+| n |Stem/m2 |Stem density |
+
 
 

--- a/docs/source/user/overview.rst
+++ b/docs/source/user/overview.rst
@@ -14,6 +14,7 @@ Understanding oriented section
    Communal-slides-related-to-FATES
    Current-Unsupported-or-Broken-Features
    Fixed-Biogeography-Mode
+   Model-Initialization-Modes
    Namelist-Options-and-Run-Time-Modes
    Notes-on-the-Parameter-File
    PARTEH-Modes


### PR DESCRIPTION
This PR updates the section on inventory initialisation to reflect the simplified file formats describing cohorts and patches. This PR accompanies PR  [#1104](https://github.com/NGEET/fates/pull/1104) on the FATES side that removes  unnecessary columns from the files describing patch and cohort structure.  
