### PR TITLE
Update the HLM API table to reflect recent updates and include future plans

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,7 @@
 
 # sphinx-fortran
 sphinx>=3.2.1
+sphinx-rtd-theme
 sphinx-fortran==1.1.1
 six
 numpy

--- a/docs/source/user/Table-of-FATES-API-and-HLM-STATUS.md
+++ b/docs/source/user/Table-of-FATES-API-and-HLM-STATUS.md
@@ -4,6 +4,13 @@ The following table list the FATES API and the corresponding HLM tag associated 
 
 | FATES API   | CTSM Tag | E3SM Hash | Notes |
 | ----------- | -------- | --------- | ----- |
+| API 31.0.0 | | | FATES landuse V1 |
+| API 30.0.0 | | | Long duration exact restart fix |
+| API 29.1.0 | | | Parameter file update, tree allometry |
+| API 29.0.0 | | | Heterotropic respiration exact restart fix |
+| [API 28.0.0](https://github.com/NGEET/fates/releases/tag/sci.1.68.0_api.28.0.0) | [ctsm5.1.dev146](https://github.com/ESCOMP/CTSM/releases/tag/ctsm5.1.dev146) | | Cross-grid seed dispersal |
+| [API 27.0.0](https://github.com/NGEET/fates/releases/tag/sci.1.67.1_api.27.0.0) | [ctsm5.1.dev134](https://github.com/ESCOMP/CTSM/releases/tag/ctsm5.1.dev134) | [4b00636](https://github.com/E3SM-Project/E3SM/commit/4b0063682c2f61eebb5eb8c7d99d13926532caff) | FATES CLM BGC compatibility |
+| [API 26.0.0](https://github.com/NGEET/fates/releases/tag/sci.1.67.1_api.26.0.0) | [ctsm5.1.dev133](https://github.com/ESCOMP/CTSM/releases/tag/ctsm5.1.dev133) | [4b00636](https://github.com/E3SM-Project/E3SM/commit/4b0063682c2f61eebb5eb8c7d99d13926532caff) | Patch and cohort refactor |
 | [API 25.5.0](https://github.com/NGEET/fates/releases/tag/sci.1.66.0_api.25.5.0) | [ctsm5.1.dev130](https://github.com/ESCOMP/CTSM/releases/tag/ctsm5.1.dev130) | [c0300fa](https://github.com/E3SM-Project/E3SM/commit/c0300fa61e40d7130ee3a16dbdd2a36efed34705) | Drought deciduous phenology update |
 | [API 25.4.0](https://github.com/NGEET/fates/releases/tag/sci.1.65.2_api.25.4.0) | [ctsm5.1.dev121](https://github.com/ESCOMP/CTSM/releases/tag/ctsm5.1.dev121) | [c0300fa](https://github.com/E3SM-Project/E3SM/commit/c0300fa61e40d7130ee3a16dbdd2a36efed34705) | NoComp initialization update |
 | [API 25.3.0](https://github.com/NGEET/fates/releases/tag/sci.1.65.0_api.25.3.0) | [ctsm5.1.dev121](https://github.com/ESCOMP/CTSM/releases/tag/ctsm5.1.dev121) | [c0300fa](https://github.com/E3SM-Project/E3SM/commit/c0300fa61e40d7130ee3a16dbdd2a36efed34705) | Kumarathunge photosynthetic temperature acclimation |


### PR DESCRIPTION
This brings the table up to date to reflect API26, 27 and 28 update.  It also includes the API update plan looking forward.