### PR TITLE
update tech-doc link to be agnostic to rtd version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
     'rtd': ('https://docs.readthedocs.io/en/stable/', None),
-    'fates-doc': ('https://fates-users-guide.readthedocs.io/projects/tech-doc/en/stable/', None),
+    'fates-doc': ('https://fates-users-guide.readthedocs.io/projects/tech-doc/en/', None),
 }
 intersphinx_disabled_domains = ['std']
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ This document is structured in four parts:
    tutorials
    user/users-guide
    developer/developer-guide
-   FATES Technical Document <https://fates-users-guide.readthedocs.io/projects/tech-doc/en/stable/>
+   FATES Technical Document <https://fates-users-guide.readthedocs.io/projects/tech-doc/en/>
    
 The tutorial will help the new user's and developers orient themselves to fates.  The user's guide is concerned with providing researchers with information on running the FATES model.  The developer's guide focuses on helping researchers and engineers contribute to the FATES model code.  Both the user and developer guide sections follow a common structure comprised of three sub-sections: 
 


### PR DESCRIPTION
RTD can control the default version via the admin settings.  Making a minor change to not link to a specific rtd version.