### PR TITLE
Fix minor typo in the user's guide.

### DIFF
--- a/docs/source/developer/Tagging-Methodology.md
+++ b/docs/source/developer/Tagging-Methodology.md
@@ -24,7 +24,7 @@ sci minor: If content has been added that changes scientific hypotheses, or chan
 
 sci bugfix: As the name implies, if a bug has been fixed, or there have been cosmetic-only changes, or accessory changes
 
-api major: If we change the communication with FATES and its host, in such a way that FATES is no-longer backwards compatible with the HLM. When this happens, we must make synchronized API changes to the host land model. For the compatability match history, see {doc}`/user/Table-of-FATES-API-and-HLM-STATUS`.
+api major: If we change the communication with FATES and its host, in such a way that FATES is no-longer backwards compatible with the HLM. When this happens, we must make synchronized API changes to the host land model. For the compatibility match history, see {doc}`/user/Table-of-FATES-API-and-HLM-STATUS`.
 
 api minor: If changes are made to the FATES API that are still  backwards compatible. An example of this would be an update to structure of the FATES parameter file.  The user would not need to update which version of the HLM they use, but they would need to use a new parameter file structure.
 

--- a/docs/source/user/Table-of-FATES-API-and-HLM-STATUS.md
+++ b/docs/source/user/Table-of-FATES-API-and-HLM-STATUS.md
@@ -1,4 +1,4 @@
-# FATES-HLM API Compatability Table
+# FATES-HLM API Compatibility Table
 
 The following table list the FATES API and the corresponding HLM tag associated with that API update.  Note that CTSM provides a specific tag for each of its merge commits to the master branch whereas E3SM does not.  As such, the hash for the relevant merge commit is provided for E3SM.  Entries that specifically link to a pull request (e.g. PR#XXXX) are provided to note updates which have not been integrated yet, but are pending.  The table may also include future planned API updates without links to provide users an advanced look at what updates are forthcoming.
 

--- a/docs/source/user/faq.rst
+++ b/docs/source/user/faq.rst
@@ -64,7 +64,7 @@ See the :doc:`../running-fates-walkthrough` tutorial.  It includes a basic scrip
 
 What version of FATES should I be running?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-*Add a cross-reference here to the hlm-fates compatability table*
+*Add a cross-reference here to the hlm-fates compatibility table*
 
 
 I ran FATES successfully!  How do I view the multiplexed dimensions?


### PR DESCRIPTION
Fixing one misspelt word in the document.