### PR TITLE
Add parameter file modification recipe to the how-to section

### DIFF
--- a/docs/source/user/how-to.rst
+++ b/docs/source/user/how-to.rst
@@ -1,12 +1,11 @@
 How-To
 ======
 
-Don't mix this up with Tutorials.  Common user questions
-Recipe analogy (addresses specific question e.g. "how to make crab salad")
-Problem oriented
+.. Don't mix this up with Tutorials.  This section should address common user questions.  How-to guides are analogous to cookbook recipes in that it addresses a specific question e.g. "how to make crab salad"
 
 .. toctree::
    :maxdepth: 1
-      
+
+   parameter-file-modification
    Authenticating-the-NCAR-SVN-Repository
    Running-FATES-with-the-selective-logging-module-activated

--- a/docs/source/user/parameter-file-modification.rst
+++ b/docs/source/user/parameter-file-modification.rst
@@ -1,0 +1,2 @@
+How to modify the FATES parameter file
+--------------------------------------


### PR DESCRIPTION
The page should explain how to modify the parameter file in a generic manner referencing the python tooling available in the `tools` section.