### PR TITLE
Add note on the supported machine for E3SM

### DIFF
--- a/docs/source/tutorial/HPC/running-fates-walkthrough-case2.rst
+++ b/docs/source/tutorial/HPC/running-fates-walkthrough-case2.rst
@@ -164,7 +164,7 @@ A sample of output data has been pre-generated for visualizing run 2.  Head back
 
     $ cd <path>/FatesTutorial_Feb2019/Data/run2_1x1brazil_structured
 
-On cori: 
+On perlmutter: 
 
 .. code-block:: shell
 

--- a/docs/source/tutorial/HPC/running-fates-walkthrough-case2.rst
+++ b/docs/source/tutorial/HPC/running-fates-walkthrough-case2.rst
@@ -164,7 +164,7 @@ A sample of output data has been pre-generated for visualizing run 2.  Head back
 
     $ cd <path>/FatesTutorial_Feb2019/Data/run2_1x1brazil_structured
 
-On perlmutter: 
+On cori: 
 
 .. code-block:: shell
 

--- a/docs/source/tutorial/HPC/running-fates-walkthrough.rst
+++ b/docs/source/tutorial/HPC/running-fates-walkthrough.rst
@@ -11,7 +11,8 @@ Materials
 1. This course is supported on the following HPCs
 
    * For CTSM: **cheyenne**
-   * For E3SM: **perlmutter**
+   * For E3SM: **cori**. 
+     * **Important**: _cori_ has been retired, the currently supported HPC is **perlmutter**. Most of the settings for _cori_ should still be applicable to _perlmutter_.
 
 2. Modest computational allocation
 3. The “FATESTutorialPacket_Feb2019.tgz” packet

--- a/docs/source/tutorial/HPC/running-fates-walkthrough.rst
+++ b/docs/source/tutorial/HPC/running-fates-walkthrough.rst
@@ -10,8 +10,6 @@ Materials
 ^^^^^^^^^
 1. This course is supported on the following HPCs
 
-   * For CTSM: **cheyenne**
-   * For E3SM: **cori**. 
    * For CTSM: **cheyenne** [#]_
    * For E3SM: **cori** [#]_
 

--- a/docs/source/tutorial/HPC/running-fates-walkthrough.rst
+++ b/docs/source/tutorial/HPC/running-fates-walkthrough.rst
@@ -11,7 +11,7 @@ Materials
 1. This course is supported on the following HPCs
 
    * For CTSM: **cheyenne**
-   * For E3SM: **cori**
+   * For E3SM: **perlmutter**
 
 2. Modest computational allocation
 3. The “FATESTutorialPacket_Feb2019.tgz” packet

--- a/docs/source/tutorial/HPC/running-fates-walkthrough.rst
+++ b/docs/source/tutorial/HPC/running-fates-walkthrough.rst
@@ -12,7 +12,8 @@ Materials
 
    * For CTSM: **cheyenne**
    * For E3SM: **cori**. 
-     * **Important**: _cori_ has been retired, the currently supported HPC is **perlmutter**. Most of the settings for _cori_ should still be applicable to _perlmutter_.
+   * For CTSM: **cheyenne** [#]_
+   * For E3SM: **cori** [#]_
 
 2. Modest computational allocation
 3. The “FATESTutorialPacket_Feb2019.tgz” packet
@@ -52,4 +53,10 @@ The tutorial is split into four different sections:
    running-fates-walkthrough-case1
    running-fates-walkthrough-case2
    running-fates-walkthrough-case3
-   
+
+
+.. [#] Cheyenne has been retired and replaced by `Derecho`_.  Most of the settings should still be applicable.
+.. [#] Cori has been retired and replaced by `Perlmutter`_.  Most of the settings should still be applicable.
+
+.. _Perlmutter: https://docs.nersc.gov/systems/perlmutter/architecture/
+.. _Derecho: https://ncar-hpc-docs.readthedocs.io/en/latest/compute-systems/derecho/


### PR DESCRIPTION
The HPC tutorial was carried out in 2019, and we don't have an equivalent one for the currently supported machines. I added a quick note saying that the materials related to cori should be mostly still applicable to perlmutter. This may be useful for new users unaware of the previous machines.