### PR TITLE
Update readthedocs build os

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
     python: "3.9"
     # You can also specify other tool versions:


### PR DESCRIPTION
Per an email notification, the the `ubuntu-20.04` build os for read the docs is going to be depricated.  This updates the read the docs yaml config file to always use the latest ubuntu lts instead of a specific version.